### PR TITLE
Execute shell scripts in a directory for post-backup tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,20 @@ docker run -d --restart=always -e DB_USER=user123 -e DB_PASS=pass123 -e DB_DUMP_
 As the scripts are _sourced_ inside the [entrypoint](https://github.com/deitch/mysql-backup/blob/master/entrypoint) script, all variables defined in it are available in the post processing script. For example, the following script will rename the backup file after the dump is done:
 
 ````bash
+#!/bin/bash
+# Rename backup file.
 new_name=${now}.gz
 
 echo "Renaming backup file from ${TARGET} to ${new_name}"
 
-if [ -e ${uri[path]}/${TARGET} ];
+if [ -e ${TMPDIR}/${TARGET} ];
 then
-  mv ${uri[path]}/${TARGET} ${uri[path]}/${new_name}
+  mv ${TMPDIR}/${TARGET} ${TMPDIR}/${new_name}
+  TARGET=${new_name}
 else
-  echo "ERROR: Backup file ${uri[path]}/${TARGET} does not exist!"
+  echo "ERROR: Backup file ${TMPDIR}/${TARGET} does not exist!"
 fi
+
 ````
 
 You can think of this as a sort of basic plugin system. Look at the source of the [entrypoint](https://github.com/deitch/mysql-backup/blob/master/entrypoint) script for other variables that can be used.

--- a/entrypoint
+++ b/entrypoint
@@ -160,6 +160,16 @@ else
     # make the dump
     mysqldump -h $DBSERVER -u$DBUSER -p$DBPASS $DB_LIST | gzip > ${TMPDIR}/${TARGET}
 
+    # Execute additional scripts for post porcessing. For example, create a new
+    # backup file containing this db backup and a second tar file with the
+    # contents of a wordpress install.
+    if [ "$(ls -A /scripts.d/post-backup/)" ];
+    then
+      for i in $(ls /scripts.d/post-backup/*.sh);do
+          source $i
+      done
+    fi
+
     # what kind of target do we have? Plain filesystem? smb?
     case "${uri[schema]}" in
       "file")
@@ -193,15 +203,6 @@ else
         /bin/rm ${TMPDIR}/${TARGET}
        ;;
     esac
-
-    # Execute additional scripts. For example, create a new backup file containing
-    # this db backup and a second tar file with the contents of a wordpress install.
-    if [ "$(ls -A /scripts.d/)" ];
-    then
-      for i in $(ls /scripts.d/post-backup/*.sh);do
-          source $i
-      done
-    fi
 
     # wait
     sleep $(($DB_DUMP_FREQ*60))

--- a/entrypoint
+++ b/entrypoint
@@ -198,7 +198,7 @@ else
     # this db backup and a second tar file with the contents of a wordpress install.
     if [ "$(ls -A /scripts.d/)" ];
     then
-      for i in $(ls /scripts.d/*.sh);do
+      for i in $(ls /scripts.d/post-backup/*.sh);do
           source $i
       done
     fi

--- a/entrypoint
+++ b/entrypoint
@@ -194,6 +194,15 @@ else
        ;;
     esac
 
+    # Execute additional scripts. For example, create a new backup file containing
+    # this db backup and a second tar file with the contents of a wordpress install.
+    if [ "$(ls -A /scripts.d/)" ];
+    then
+      for i in $(ls /scripts.d/*.sh);do
+          source $i
+      done
+    fi
+
     # wait
     sleep $(($DB_DUMP_FREQ*60))
   done

--- a/scripts.d/post-backup/rename_backup.sh.example
+++ b/scripts.d/post-backup/rename_backup.sh.example
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Rename backup file.
+
+new_name=${now}.gz
+
+echo "Renaming backup file from ${TARGET} to ${new_name}"
+
+if [ -e ${TMPDIR}/${TARGET} ];
+then
+  mv ${TMPDIR}/${TARGET} ${TMPDIR}/${new_name}
+  TARGET=${new_name}
+else
+  echo "ERROR: Backup file ${TMPDIR}/${TARGET} does not exist!"
+fi


### PR DESCRIPTION
Hi,

Sometimes there's the need to do some post backup tasks, like backup a website along with some other files like a wordpress install directory, or rename the backup file to something else, etc. 

This PR adds a feature to execute the scripts in a directory named _scripts.d_ at the end of the backup process. 

For example, as the script is sourced all the variables defined in the main script (_entrypoint_) can be accessed:

```
# Rename backup file.

new_name=${now}.gz

echo "Renaming backup file from ${TARGET} to ${new_name}"

if [ -e ${uri[path]}/${TARGET} ];
then
  mv ${uri[path]}/${TARGET} ${uri[path]}/${new_name}
else
  echo "ERROR: Backup file ${uri[path]}/${TARGET} does not exist!"
fi

```