### PR TITLE
Enable reading variables from files as well (docker/rancher secrets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To run a backup, launch `mysql-backup` image as a container with the correct par
 For example:
 
 ````bash
-docker run -d --restart=always -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=2330 -e DB_DUMP_TARGET=/db -e DBSERVER=my-db-container -v /local/file/path:/db deitch/mysql-backup
+docker run -d --restart=always -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=2330 -e DB_DUMP_TARGET=/db -e DB_SERVER=my-db-container -v /local/file/path:/db deitch/mysql-backup
 ````
 
 The above will run a dump every 60 minutes, beginning at the next 2330 local time, from the database accessible in the container `my-db-container`.
@@ -29,8 +29,8 @@ The following are the environment variables for a backup:
 
 __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables-e-env-env-file) to keep your secrets out of your shell history__
 
-* `DBSERVER`: hostname to connect to database. Required.
-* `DBPORT`: port to use to connect to database. Optional, defaults to `3306`
+* `DB_SERVER`: hostname to connect to database. Required.
+* `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
 * `DB_USER`: username for the database
 * `DB_PASS`: password for the database
 * `DB_NAMES`: names of databases to dump; defaults to all databases in the database server
@@ -53,10 +53,10 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 In addition, any environment variable that starts with `MYSQLDUMP_` will have the `MYSQLDUMP_` part stripped off, and the rest passed as an option to `mysqldump`. For example, `MYSQLDUMP_max_allowed_packet=123455678` will run `mysqldump --max_allowed_packet=123455678`.
 
 ### Database Container
-In order to perform the actual dump, `mysql-backup` needs to connect to the database container. You **must** pass the database hostname - which can be another container or any database process accessible from the backup container - by passing the environment variable `DBSERVER` with the hostname or IP address of the database. You **may** override the default port of `3306` by passing the environment variable `DBPORT`.
+In order to perform the actual dump, `mysql-backup` needs to connect to the database container. You **must** pass the database hostname - which can be another container or any database process accessible from the backup container - by passing the environment variable `DB_SERVER` with the hostname or IP address of the database. You **may** override the default port of `3306` by passing the environment variable `DB_PORT`.
 
 ````bash
-docker run -d --restart=always -e DB_USER=user123 -e DB_PASS=pass123 -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=2330 -e DB_DUMP_TARGET=/db -e DBSERVER=my-db-container -v /local/file/path:/db deitch/mysql-backup
+docker run -d --restart=always -e DB_USER=user123 -e DB_PASS=pass123 -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=2330 -e DB_DUMP_TARGET=/db -e DB_SERVER=my-db-container -v /local/file/path:/db deitch/mysql-backup
 ````
 
 ### Dump Target
@@ -96,7 +96,7 @@ To use them you need to add a host volume that points to the post-backup scripts
 
 ````bash
 docker run -d --restart=always -e DB_USER=user123 -e DB_PASS=pass123 -e DB_DUMP_FREQ=60 \
-  -e DB_DUMP_BEGIN=2330 -e DB_DUMP_TARGET=/db -e DBSERVER=my-db-container:db \
+  -e DB_DUMP_BEGIN=2330 -e DB_DUMP_TARGET=/db -e DB_SERVER=my-db-container:db \
   -v /path/to/pre-backup/scripts:/scripts.d/pre-backup \
   -v /path/to/post-backup/scripts:/scripts.d/post-backup \
   -v /local/file/path:/db \
@@ -121,7 +121,7 @@ services:
      - DB_PASS=pass123
      - DB_DUMP_FREQ=60
      - DB_DUMP_BEGIN=2330
-     - DBSERVER=mysql_db
+     - DB_SERVER=mysql_db
   mysql_db:
     image: mysql
     ....

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The above will run a dump every 60 minutes, beginning at the next 2330 local tim
 
 The following are the environment variables for a backup:
 
-__You should consider the [use of `--env-file=`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables-e-env-env-file) to keep your secrets out of your shell history__
+__You should consider the [use of `--env-file=`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables-e-env-env-file), [docker secrets](https://docs.docker.com/engine/swarm/secrets/) to keep your secrets out of your shell history__
 
 * `DB_SERVER`: hostname to connect to database. Required.
 * `DB_PORT`: port to use to connect to database. Optional, defaults to `3306`
@@ -177,9 +177,25 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 
 Examples:
 
-1. Restore from a local file: `docker run  -e DB_USER=user123 -e DB_PASS=pass123 -e DB_RESTORE_TARGET=/backup/db_backup_201509271627.sql.gz -v /local/path:/backup deitch/mysql-backup`
-2. Restore from an SMB file: `docker run  -e DB_USER=user123 -e DB_PASS=pass123 -e DB_RESTORE_TARGET=smb://smbserver/share1/backup/db_backup_201509271627.sql.gz deitch/mysql-backup`
-3. Restore from an S3 file: `docker run  -e AWS_ACCESS_KEY_ID=awskeyid -e AWS_SECRET_ACCESS_KEY=secret -e AWS_DEFAULT_REGION=eu-central-1 -e DB_USER=user123 -e DB_PASS=pass123 -e DB_RESTORE_TARGET=s3://bucket/path/db_backup_201509271627.sql.gz deitch/mysql-backup`
+1. Restore from a local file: `docker run -e DB_USER=user123 -e DB_PASS=pass123 -e DB_RESTORE_TARGET=/backup/db_backup_201509271627.sql.gz -v /local/path:/backup deitch/mysql-backup`
+2. Restore from an SMB file: `docker run -e DB_USER=user123 -e DB_PASS=pass123 -e DB_RESTORE_TARGET=smb://smbserver/share1/backup/db_backup_201509271627.sql.gz deitch/mysql-backup`
+3. Restore from an S3 file: `docker run -e AWS_ACCESS_KEY_ID=awskeyid -e AWS_SECRET_ACCESS_KEY=secret -e AWS_DEFAULT_REGION=eu-central-1 -e DB_USER=user123 -e DB_PASS=pass123 -e DB_RESTORE_TARGET=s3://bucket/path/db_backup_201509271627.sql.gz deitch/mysql-backup`
+
+### Using docker (or rancher) secrets
+Environment variables used in this image can be passed in files as well. This is useful when you are using docker (or rancher) secrets for storing sensitive information.
+
+As you can set environment variable with `-e ENVIRONMENT_VARIABLE=value`, you can also use `-e ENVIRONMENT_VARIABLE_FILE=/path/to/file`. Contents of that file will be assigned to the environment variable.
+
+**Example:**
+
+```bash
+docker run -d \
+  -e DB_HOST_FILE=/run/secrets/DB_HOST \
+  -e DB_USER_FILE=/run/secrets/DB_USER \
+  -e DB_PASS_FILE=/run/secrets/DB_PASS \
+  -v /local/file/path:/db \
+  deitch/mysql-backup
+```
 
 ### Restore pre and post processing
 
@@ -195,7 +211,7 @@ the db backup and a second tarball with the contents of a WordPress install on
 For an example take a look at the post-backup examples, all variables defined for post-backup scripts are available for pre-processing too. Also don't forget to add the same host volumes for `pre-restore` and `post-restore` directories as described for post-backup processing.
 
 ### Automated Build
-This gituhub repo is the source for the mysql-backup image. The actual image is stored on the docker hub at `deitch/mysql-backup`, and is triggered with each commit to the source by automated build via Webhooks.
+This github repo is the source for the mysql-backup image. The actual image is stored on the docker hub at `deitch/mysql-backup`, and is triggered with each commit to the source by automated build via Webhooks.
 
 There are 2 builds: 1 for version based on the git tag, and another for the particular version number.
 

--- a/entrypoint
+++ b/entrypoint
@@ -6,28 +6,6 @@ if [[ -n "$DB_DUMP_DEBUG" ]]; then
   set -x
 fi
 
-# usage: file_env VAR [DEFAULT]
-#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
-# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
-#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature
-function file_env() {
-	local var="$1"
-	local fileVar="${var}_FILE"
-	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
-		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
-		exit 1
-	fi
-	local val="$def"
-	if [ "${!var:-}" ]; then
-		val="${!var}"
-	elif [ "${!fileVar:-}" ]; then
-		val="$(< "${!fileVar}")"
-	fi
-	export "$var"="$val"
-	unset "$fileVar"
-}
-
 # get all variables from environment variables or files (e.g. VARIABLE_NAME_FILE)
 # (setting defaults happens here, too)
 file_env "DB_SERVER"
@@ -107,27 +85,27 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
       fi
     done
   fi
-	uri_parser ${DB_RESTORE_TARGET}
+  uri_parser ${DB_RESTORE_TARGET}
   if [[ "${uri[schema]}" == "file" ]]; then
     cp $DB_RESTORE_TARGET $TMPRESTORE 2>/dev/null
   elif [[ "${uri[schema]}" == "s3" ]]; then
     aws s3 cp "$DB_RESTORE_TARGET" $TMPRESTORE
-	elif [[ "${uri[schema]}" == "smb" ]]; then
+  elif [[ "${uri[schema]}" == "smb" ]]; then
     if [[ -n "$SMB_USER" ]]; then
       UPASSARG="-U"
-			UPASS="${SMB_USER}%${SMB_PASS}"
-		elif [[ -n "${uri[user]}" ]]; then
+      UPASS="${SMB_USER}%${SMB_PASS}"
+    elif [[ -n "${uri[user]}" ]]; then
       UPASSARG="-U"
-			UPASS="${uri[user]}%${uri[password]}"
-		else
+      UPASS="${uri[user]}%${uri[password]}"
+    else
       UPASSARG=
-			UPASS=
-		fi
-		if [[ -n "${uri[userdomain]}" ]]; then
-			UDOM="-W ${uri[userdomain]}"
-		else
-			UDOM=
-		fi
+      UPASS=
+    fi
+    if [[ -n "${uri[userdomain]}" ]]; then
+      UDOM="-W ${uri[userdomain]}"
+    else
+      UDOM=
+    fi
     smbclient -N "//${uri[host]}/${uri[share]}" ${UPASSARG} "${UPASS}" ${UDOM} -c "get ${uri[sharepath]} ${TMPRESTORE}"
   fi
   # did we get a file?
@@ -149,8 +127,8 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
     done
   fi
 else
-	# determine target proto
-	uri_parser ${DB_DUMP_TARGET}
+  # determine target proto
+  uri_parser ${DB_DUMP_TARGET}
 
   # wait for the next time to start a backup
   # for debugging
@@ -232,7 +210,7 @@ else
       "smb")
         if [[ -n "$SMB_USER" ]]; then
           UPASSARG="-U"
-    			UPASS="${SMB_USER}%${SMB_PASS}"
+          UPASS="${SMB_USER}%${SMB_PASS}"
         elif [[ -n "${uri[user]}" ]]; then
           UPASSARG="-U"
           UPASS="${uri[user]}%${uri[password]}"

--- a/entrypoint
+++ b/entrypoint
@@ -63,14 +63,14 @@ done
 
 
 # database server
-if [ -z "${DBSERVER}" ]; then
-  echo "DBSERVER variable is required. Exiting."
+if [ -z "${DB_SERVER}" ]; then
+  echo "DB_SERVER variable is required. Exiting."
   exit 1
 fi
 # database port
-if [ -z "${DBPORT}" ]; then
-  echo "DBPORT not provided, defaulting to 3306"
-  DBPORT=3306
+if [ -z "${DB_PORT}" ]; then
+  echo "DB_PORT not provided, defaulting to 3306"
+  DB_PORT=3306
 fi
 
 
@@ -119,7 +119,7 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
   fi
   # did we get a file?
   if [[ -f "$TMPRESTORE" ]]; then
-    gunzip < $TMPRESTORE | mysql -h $DBSERVER -P $DBPORT $DBUSER $DBPASS
+    gunzip < $TMPRESTORE | mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS
     /bin/rm -f $TMPRESTORE
     exit 0
   else
@@ -191,7 +191,7 @@ else
     fi
 
     # make the dump
-    mysqldump -h $DBSERVER -P $DBPORT $DBUSER $DBPASS $DB_LIST $DUMPVARS | gzip > ${TMPDIR}/${TARGET}
+    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST | gzip > ${TMPDIR}/${TARGET}
 
     # Execute additional scripts for post porcessing. For example, create a new
     # backup file containing this db backup and a second tar file with the

--- a/entrypoint
+++ b/entrypoint
@@ -30,18 +30,31 @@ function file_env() {
 
 # get all variables from environment variables or files (e.g. VARIABLE_NAME_FILE)
 # (setting defaults happens here, too)
+file_env "DB_SERVER"
+file_env "DB_PORT"
 file_env "DB_USER"
 file_env "DB_PASS"
 file_env "DB_NAMES"
+
 file_env "DB_DUMP_FREQ" "1440"
 file_env "DB_DUMP_BEGIN" "+0"
 file_env "DB_DUMP_DEBUG"
 file_env "DB_DUMP_TARGET" "/backup"
+
+file_env "DB_RESTORE_TARGET"
+
+file_env "AWS_ENDPOINT_URL"
+file_env "AWS_ENDPOINT_OPT"
 file_env "AWS_ACCESS_KEY_ID"
 file_env "AWS_SECRET_ACCESS_KEY"
 file_env "AWS_DEFAULT_REGION"
+
 file_env "SMB_USER"
 file_env "SMB_PASS"
+
+if [[ -n "$DB_DUMP_DEBUG" ]]; then
+  set -x
+fi
 
 # login credentials
 if [ -n "${DB_USER}" ]; then

--- a/entrypoint
+++ b/entrypoint
@@ -6,13 +6,43 @@ if [[ -n "$DB_DUMP_DEBUG" ]]; then
   set -x
 fi
 
-# set our defaults
-# DB_DUMP_FREQ = how often to run a backup in minutes, i.e. how long to wait from the most recently completed to the next
-DB_DUMP_FREQ=${DB_DUMP_FREQ:-1440}
-# DB_DUMP_BEGIN = what time to start the first backup upon execution. If starts with '+' it means, "in x minutes"
-DB_DUMP_BEGIN=${DB_DUMP_BEGIN:-+0}
-# DB_DUMP_TARGET = where to place the backup file. Can be URL (e.g. smb://server/share/path) or just file path /foo
-DB_DUMP_TARGET=${DB_DUMP_TARGET:-/backup}
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature
+function file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# get all variables from environment variables or files (e.g. VARIABLE_NAME_FILE)
+# (setting defaults happens here, too)
+file_env "DB_USER"
+file_env "DB_PASS"
+file_env "DB_NAMES"
+file_env "DB_DUMP_FREQ" "1440"
+file_env "DB_DUMP_BEGIN" "+0"
+file_env "DB_DUMP_DEBUG"
+file_env "DB_DUMP_TARGET" "/backup"
+file_env "AWS_ACCESS_KEY_ID"
+file_env "AWS_SECRET_ACCESS_KEY"
+file_env "AWS_DEFAULT_REGION"
+file_env "SMB_USER"
+file_env "SMB_PASS"
+
 # login credentials
 if [ -n "${DB_USER}" ]; then
   DBUSER="-u${DB_USER}"

--- a/functions.sh
+++ b/functions.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
 # Function definitions used in the entrypoint file.
 
+#
+# Environment variable reading function
+#
+# The function enables reading environment variable from file.
+#
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature
+function file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
 
 #
 # URI parsing function

--- a/test/test.sh
+++ b/test/test.sh
@@ -72,7 +72,7 @@ function runtest() {
 
 
 	# change our target
-  cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v /tmp/backups/${seqno}/post-backup:/scripts.d/post-backup -v /tmp/backups:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
+  cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v /tmp/backups/${seqno}/:/scripts.d/ -v /tmp/backups:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
 	echo $cid
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -72,7 +72,7 @@ function runtest() {
 
 
 	# change our target
-  cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v /tmp/backups/${seqno}/:/scripts.d/ -v /tmp/backups:/backups -e DBSERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
+  cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v /tmp/backups/${seqno}/post-backup:/scripts.d/post-backup -v /tmp/backups:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
 	echo $cid
 }
 


### PR DESCRIPTION
(Closes #26)

Used the same `file_env` function from mysql image's entrypoint (https://github.com/docker-library/mysql/blob/0590e4efd2b31ec794383f084d419dea9bc752c4/5.7/docker-entrypoint.sh#L25).