### PR TITLE
Pre post scripts

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -106,7 +106,12 @@ if [[ -n "$DB_RESTORE_TARGET" ]]; then
   if [ -d /scripts.d/pre-restore/ ]; then
     for i in $(ls /scripts.d/pre-restore/*.sh); do
       if [ -x $i ]; then
-        DB_RESTORE_TARGET=${DB_RESTORE_TARGET} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} $i
+        #The script must output the name of the sql dump so processing
+        #continues as usual
+        DB_RESTORE_TARGET=$(DB_RESTORE_TARGET=${DB_RESTORE_TARGET} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} $i)
+        if [ $? -gt 0 ]; then
+            echo "pre-restore: script $i failed with exit code: $?" && exit 1
+        fi
       fi
     done
   fi
@@ -191,7 +196,7 @@ else
         fi
       done
     fi
-    
+
     # what is the name of our target?
     now=$(date -u +"%Y%m%d%H%M%S")
     TARGET=db_backup_${now}.gz

--- a/scripts.d/post-backup/backup_wordpress_root.sh.example
+++ b/scripts.d/post-backup/backup_wordpress_root.sh.example
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Backup a WordPress site (db + files).
+
+NOW=$(date +"%Y-%m-%d-%H_%M")
+
+if [ -e ${DUMPFILE} ];
+then
+  backups_dir=$(dirname ${DUMPFILE})
+  tmp_dir=$(mktemp -d)
+  wordpress_files="${tmp_dir}/wordpress-${NOW}-files.tar.gz"
+  wordpress_full_backup="wordpress-${NOW}-full.tar.gz"
+
+  echo "Backing up WordPress directory"
+  tar zcf ${wordpress_files} /var/www/html/wp-content
+  [[ $? -gt 0 ]] && echo "Could not compress WordPress directory!" && exit 1
+
+  echo "Creating new tarball"
+  tar zcf ${tmp_dir}/${wordpress_full_backup} ${wordpress_files} ${DUMPFILE}
+  [[ $? -gt 0 ]] && echo "Could not create WordPress full backup file!" && exit 1
+
+  echo "Moving new backup file to: ${DUMPDIR}"
+  mv ${restore_dir}/${wordpress_full_backup} ${DUMPDIR}
+  [[ $? -gt 0 ]] && echo "Could not move the backup file to ${DUMPDIR}!" && exit 1
+
+  #cleanup
+  rm -fr ${tmp_dir}
+else
+  echo "ERROR: Backup file ${DUMPFILE} does not exist!"
+fi

--- a/scripts.d/post-backup/backup_wordpress_root.sh.example
+++ b/scripts.d/post-backup/backup_wordpress_root.sh.example
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Backup a WordPress site (db + files).
+if [[ -n "$DB_DUMP_DEBUG" ]]; then
+  set -x
+fi
 
 NOW=$(date +"%Y-%m-%d-%H_%M")
 

--- a/scripts.d/pre-restore/restore_full_backup.sh.example
+++ b/scripts.d/pre-restore/restore_full_backup.sh.example
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Backup a WordPress site (db + files).
+if [[ -n "$DB_DUMP_DEBUG" ]]; then
+  set -x
+fi
+
+if [ -n ${DB_RESTORE_TARGET} ];
+then
+  backups_dir=$(dirname ${DB_RESTORE_TARGET})
+  backup_filename=$(basename ${DB_RESTORE_TARGET})
+  tmp_dir=$(mktemp -d)
+  backup_files=""
+  sql_dump=""
+
+  >&2 echo "Getting contents of tarball"
+  IFS_ORIG=${IFS}
+  backup_files="$(tar tvf ${DB_RESTORE_TARGET}|awk '{ print $6 }' )"
+  backup_files="$(echo ${backup_files}|  tr '\n' ' ')"
+  if [ "${backup_files}" == "" ];then
+    >&2 echo "ERROR: Empty tarball!" && exit 1
+  fi
+
+  >&2 echo "Uncompressing tarball"
+  cd /${tmp_dir}
+  tar zxf ${DB_RESTORE_TARGET}
+  [[ $? -gt 0 ]] && echo "Could not uncompress tarball!" && exit 1
+
+  for i in ${backup_files}; do
+    #Get the sql dump and put it back on DB_RESTORE_TARGET as mysql-backup expects
+    if [ "${i/db_backup}" != ${i} ]; then
+      >&2 echo "Found SQL dump tarball: ${i}"
+      sql_dump=${i}
+    else
+      >&2 echo "Uncompressing tarball: ${i}"
+      tar zxf ${i} -C /
+      [[ $? -gt 0 ]] && >&2 echo "ERROR: Could not uncompress backup file: ${i}!" && exit 1
+    fi
+  done
+else
+  echo >&2 "ERROR: Backup file ${DB_RESTORE_TARGET} or restore directory does not exist!"
+fi
+
+#Echo the name of the sql dump file so the backup can continue as usual.
+echo ${backups_dir}/${sql_dump}

--- a/scripts.d/pre-restore/restore_full_backup.sh.example
+++ b/scripts.d/pre-restore/restore_full_backup.sh.example
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Backup a WordPress site (db + files).
+# Restore a backup (db + files).
 if [[ -n "$DB_DUMP_DEBUG" ]]; then
   set -x
 fi


### PR DESCRIPTION
Hi,

These are the scripts to backup and restore a wordpress site. 

**Backup script**

The backup script must run on _post-backup_, what basically does is to compress a hardcoded path pointing to wordpress root directory _/var/www/html_  (for now), and then creates a second tarball containing the _sql_ dump and the wordpress root tarball. 

The script still needs to be modified to make it generic, but for that it needs to know the list of files and directories it needs to add to the backup. This could be done with an env var for the script, but this is a whole new topic on its own: should we use a special naming nomenclature, it will receive files and directories or just the latter, which format will it use to store the values, etc. So another issue to discuss that.

**Restore script**

The restore script is more generic, it needs to run on _pre-restore_ and what it does is to uncompress the tarball defined on _DB_DUMP_RESTORE_, this file must contain at least the sql dump and one or more files tarballs. After uncompressing it, the rest of tarballs will be uncompressed on the container's root directory. This means the tarballs need to be created also from the root directory (as the backup script does). At the end the script prints the name of the sql dump file so _DP_DUMP_RESTORE_ can be updated on the main script and continue as usual with the db dump restore.

Documentation is missing, but I think I'll leave it for later after the backup script is improved.