### PR TITLE
Allow generic vars to pass options to mysqldump

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `SMB_USER`: SMB username. May also be specified in `DB_DUMP_TARGET` with an `smb://` url. If both specified, this variable overrides the value in the URL.
 * `SMB_PASS`: SMB password. May also be specified in `DB_DUMP_TARGET` with an `smb://` url. If both specified, this variable overrides the value in the URL.
 
+In addition, any environment variable that starts with `MYSQLDUMP_` will have the `MYSQLDUMP_` part stripped off, and the rest passed as an option to `mysqldump`. For example, `MYSQLDUMP_max_allowed_packet=123455678` will run `mysqldump --max_allowed_packet=123455678`.
 
 ### Database Container
 In order to perform the actual dump, `mysql-backup` needs to connect to the database container. You **must** pass the database hostname - which can be another container or any database process accessible from the backup container - by passing the environment variable `DBSERVER` with the hostname or IP address of the database. You **may** override the default port of `3306` by passing the environment variable `DBPORT`.

--- a/entrypoint
+++ b/entrypoint
@@ -25,6 +25,13 @@ else
   DBPASS=
 fi
 
+# capture our var settings
+DUMPVARS=""
+for i in $(env | awk -F_ '/^MYSQLDUMP_/ {print $2}'); do
+  DUMPVARS="${DUMPVARS} --${i}"
+done
+
+
 # database server
 if [ -z "${DBSERVER}" ]; then
   echo "DBSERVER variable is required. Exiting."
@@ -154,7 +161,7 @@ else
     fi
 
     # make the dump
-    mysqldump -h $DBSERVER -P $DBPORT $DBUSER $DBPASS $DB_LIST | gzip > ${TMPDIR}/${TARGET}
+    mysqldump -h $DBSERVER -P $DBPORT $DBUSER $DBPASS $DB_LIST $DUMPVARS | gzip > ${TMPDIR}/${TARGET}
 
     # Execute additional scripts for post porcessing. For example, create a new
     # backup file containing this db backup and a second tar file with the


### PR DESCRIPTION
Any environment variable that begins `MYSQLDUMP_` will have the first part `MYSQLDUMP_` stripped off, and the rest passed as var options to `mysqldump`.

Updated README as well.