### PR TITLE
Tie mysql to 5.7 because of auth requirements for 8.0.4+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # mysql backup image
-FROM alpine:3.6
+FROM alpine:3.7
 MAINTAINER Avi Deitcher <https://github.com/deitch>
 
 # install the necessary client

--- a/test/Dockerfile_smb
+++ b/test/Dockerfile_smb
@@ -1,5 +1,5 @@
 # rancher server backup image
-FROM alpine:3.6
+FROM alpine:3.7
 MAINTAINER https://github.com/deitch
 
 # smb port

--- a/test/test.sh
+++ b/test/test.sh
@@ -216,7 +216,7 @@ docker network create mysqltest
 [[ "$DEBUG" != "0" ]] && echo "Running smb, s3 and mysql containers"
 [[ "$DEBUG" != "0" ]] && SMB_IMAGE="$SMB_IMAGE -F -d 25"
 smb_cid=$(docker run --net mysqltest --name=smb  -d -p 445:445 -v /tmp/backups:/share/backups -t ${SMB_IMAGE})
-mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql)
+mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:5.7)
 s3_cid=$(docker run --net mysqltest --name s3 -d -v /tmp/backups:/fakes3_root/s3/mybucket lphoward/fake-s3 -r /fakes3_root -p 443)
 
 


### PR DESCRIPTION
Before we (unwisely) used `docker run mysql` in tests, which defaults to the `latest` tag. As of `mysql` version `8.0.4` and above, the default auth mechanism for `mysql` is caching sha2. Our client is based on `alpine:3.7`, whose `mysql-client` package is based on `mariadb`, which does not include that plugin.

Here we limit it.