### PR TITLE
Restore usage of DUMPVARS

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -181,7 +181,7 @@ else
     fi
 
     # make the dump
-    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST | gzip > ${TMPDIR}/${TARGET}
+    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST $DUMPVARS | gzip > ${TMPDIR}/${TARGET}
 
     # Execute additional scripts for post porcessing. For example, create a new
     # backup file containing this db backup and a second tar file with the


### PR DESCRIPTION
Fixes #51 

Restores usage of `$DUMPVARS` to `mysqldump`. It was accidentally deleted in the complex merge of #29 .