### PR TITLE
implement target name override plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 sudo: required
 
 services:
-  - docker
+- docker
 
-script:
-- make build
-- make test
+jobs:
+  include:
+  - stage: "Tests"
+    name: "core-test"
+    script:
+    - make build
+    - make test
+  - script:
+    - make build
+    - make test_source_target
+    name: "source-target-test"

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,4 @@ test:
 
 test_source_target:
 	cd test && ./test_source_target.sh
+	

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ push: build
 	docker push $(IMAGE):latest
 
 test:
-	cd test && ./test.sh
+	cd test && ./test.sh && ./test_source_target.sh

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,7 @@ push: build
 	docker push $(IMAGE):latest
 
 test:
-	cd test && ./test.sh && ./test_source_target.sh
+	cd test && ./test.sh
+
+test_source_target:
+	cd test && ./test_source_target.sh

--- a/README.md
+++ b/README.md
@@ -87,9 +87,31 @@ Note that for s3, you'll need to specify your AWS credentials and default AWS re
 #### Custom backup source file name
 There may be use-cases where you need to modify the source path of the backup file **before** it gets uploaded to the dump target. 
 An example is combining multiple compressed files into one and giving it a new name, i.e. ```db-other-files-combined.tar.gz```.
-To do that, place an executable file called ```source.sh``` in the following path:
+To do that, place an executable file called `source.sh` in the following path:
 
       /scripts.d/source.sh
+
+Whatever your script returns to _stdout_ will be used as the source name for the backup file.
+
+The following exported environment variables will be available to the script above:
+
+* `DUMPFILE`: full path in the container to the output file
+* `NOW`: date of the backup, as included in `DUMPFILE` and given by `date -u +"%Y%m%d%H%M%S"`
+* `DUMPDIR`: path to the destination directory so for example you can copy a new tarball including some other files along with the sql dump.
+* `DB_DUMP_DEBUG`: To enable debug mode in post-backup scripts.
+      
+**Example run:**
+
+      NOW=20180930151304 DUMPFILE=/tmp/backups/db_backup_201809301513.gz DUMPDIR=/backup DB_DUMP_DEBUG=true /scripts.d/source.sh
+      
+**Example custom source script:**
+  
+```bash
+  #!/bin/bash
+  
+  # Rename source file
+  echo -n "db-plus-wordpress_${NOW}.gz"
+```           
 
 #### Custom backup target file name
 There may be use-cases where you need to modify the target upload path of the backup file **before** it gets uploaded. 
@@ -106,6 +128,19 @@ The following exported environment variables will be available to the script abo
 * `NOW`: date of the backup, as included in `DUMPFILE` and given by `date -u +"%Y%m%d%H%M%S"`
 * `DUMPDIR`: path to the destination directory so for example you can copy a new tarball including some other files along with the sql dump.
 * `DB_DUMP_DEBUG`: To enable debug mode in post-backup scripts.
+
+**Example run:**
+
+      NOW=20180930151304 DUMPFILE=/tmp/backups/db_backup_201809301513.gz DUMPDIR=/backup DB_DUMP_DEBUG=true /scripts.d/target.sh
+      
+**Example custom target script:**
+  
+```bash
+  #!/bin/bash
+  
+  # Rename target file
+  echo -n "db-plus-wordpress-uploaded_${NOW}.gz"
+``` 
 
 ### Backup pre and post processing
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ If you use a URL like `s3://bucket/path`, you can have it save to an S3 bucket.
 
 Note that for s3, you'll need to specify your AWS credentials and default AWS region via `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION`
 
+#### Custom backup file name
+There may be use-cases where you need to modify the name of the backup file **before** it gets uploaded to the dump target. 
+An example is uploading a backup to a date stamped object key path in S3, i.e. ```s3://bucket/2018/08/23/path```.
+To do that, place an executable file called ```target.sh``` in the following path:
+
+      /scripts.d/target.sh
+
+Whatever your script returns to _stdout_ will be used as the name for the backup file.
+
+The following exported environment variables will be available to the script above:
+
+* `DUMPFILE`: full path in the container to the output file
+* `NOW`: date of the backup, as included in `DUMPFILE` and given by `date -u +"%Y%m%d%H%M%S"`
+* `DUMPDIR`: path to the destination directory so for example you can copy a new tarball including some other files along with the sql dump.
+* `DB_DUMP_DEBUG`: To enable debug mode in post-backup scripts.
+
 ### Backup pre and post processing
 
 Any executable script with _.sh_ extension in _/scripts.d/pre-backup/_ or _/scripts.d/post-backup/_ directories in the container will be executed before

--- a/README.md
+++ b/README.md
@@ -84,8 +84,15 @@ If you use a URL like `s3://bucket/path`, you can have it save to an S3 bucket.
 
 Note that for s3, you'll need to specify your AWS credentials and default AWS region via `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION`
 
-#### Custom backup file name
-There may be use-cases where you need to modify the name of the backup file **before** it gets uploaded to the dump target. 
+#### Custom backup source file name
+There may be use-cases where you need to modify the source path of the backup file **before** it gets uploaded to the dump target. 
+An example is combining multiple compressed files into one and giving it a new name, i.e. ```db-other-files-combined.tar.gz```.
+To do that, place an executable file called ```source.sh``` in the following path:
+
+      /scripts.d/source.sh
+
+#### Custom backup target file name
+There may be use-cases where you need to modify the target upload path of the backup file **before** it gets uploaded. 
 An example is uploading a backup to a date stamped object key path in S3, i.e. ```s3://bucket/2018/08/23/path```.
 To do that, place an executable file called ```target.sh``` in the following path:
 

--- a/entrypoint
+++ b/entrypoint
@@ -201,14 +201,12 @@ else
     # Execute a script to modify the name of the source file path before uploading to the dump target
     # For example, modifying the name of the source dump file from the default, e.g. db-other-files-combined.tar.gz
     if [ -f /scripts.d/source.sh ] && [ -x /scripts.d/source.sh ]; then
-        SOURCE=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/source.sh | tr -d '\040\011\012\015' )
+        SOURCE=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/source.sh | tr -d '\040\011\012\015')
 
         if [ -z "${SOURCE}" ]; then
             echo "Your source script located at /scripts.d/source.sh must return a value to stdout"
             exit 1
         fi
-
-        S
     fi
 
     # Execute a script to modify the name of the target file before uploading to the dump target.

--- a/entrypoint
+++ b/entrypoint
@@ -201,18 +201,20 @@ else
     # Execute a script to modify the name of the source file path before uploading to the dump target
     # For example, modifying the name of the source dump file from the default, e.g. db-other-files-combined.tar.gz
     if [ -f /scripts.d/source.sh ] && [ -x /scripts.d/source.sh ]; then
-        SOURCE=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/source.sh)
+        SOURCE=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/source.sh | tr -d '\040\011\012\015' )
 
         if [ -z "${SOURCE}" ]; then
             echo "Your source script located at /scripts.d/source.sh must return a value to stdout"
             exit 1
         fi
+
+        S
     fi
 
     # Execute a script to modify the name of the target file before uploading to the dump target.
     # For example, uploading to a date stamped object key path in S3, i.e. s3://bucket/2018/08/23/path
     if [ -f /scripts.d/target.sh ] && [ -x /scripts.d/target.sh ]; then
-        TARGET=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/target.sh)
+        TARGET=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/target.sh | tr -d '\040\011\012\015')
 
         if [ -z "${TARGET}" ]; then
             echo "Your target script located at /scripts.d/target.sh must return a value to stdout"

--- a/entrypoint
+++ b/entrypoint
@@ -198,6 +198,17 @@ else
       done
     fi
 
+    # Execute a script to modify the name of the source file path before uploading to the dump target
+    # For example, modifying the name of the source dump file from the default, e.g. db-other-files-combined.tar.gz
+    if [ -f /scripts.d/source.sh ] && [ -x /scripts.d/source.sh ]; then
+        SOURCE=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/source.sh)
+
+        if [ -z "${SOURCE}" ]; then
+            echo "Your source script located at /scripts.d/source.sh must return a value to stdout"
+            exit 1
+        fi
+    fi
+
     # Execute a script to modify the name of the target file before uploading to the dump target.
     # For example, uploading to a date stamped object key path in S3, i.e. s3://bucket/2018/08/23/path
     if [ -f /scripts.d/target.sh ] && [ -x /scripts.d/target.sh ]; then

--- a/entrypoint
+++ b/entrypoint
@@ -194,6 +194,17 @@ else
       done
     fi
 
+    # Execute a script to modify the name of the target file before uploading to the dump target.
+    # For example, uploading to a date stamped object key path in S3, i.e. s3://bucket/2018/08/23/path
+    if [ -f /scripts.d/target.sh ] && [ -x /scripts.d/target.sh ]; then
+        TARGET=$(NOW=${now} DUMPFILE=${TMPDIR}/${TARGET} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/target.sh)
+
+        if [ -z "${TARGET}" ]; then
+            echo "Your target script located at /scripts.d/target.sh must return a value to stdout"
+            exit 1
+        fi
+    fi
+
     # what kind of target do we have? Plain filesystem? smb?
     case "${uri[schema]}" in
       "file")

--- a/entrypoint
+++ b/entrypoint
@@ -171,9 +171,13 @@ else
       done
     fi
 
-    # what is the name of our target?
+    # what is the name of our source and target?
     now=$(date -u +"%Y%m%d%H%M%S")
-    TARGET=db_backup_${now}.gz
+    # SOURCE: file that the uploader looks for when performing the upload
+    # TARGET: the remote file that is actually uploaded
+    SOURCE=db_backup_${now}.gz
+    TARGET=${SOURCE}
+
     if [[ -n "$DB_NAMES" ]]; then
       DB_LIST="--databases $DB_NAMES"
     else
@@ -181,7 +185,7 @@ else
     fi
 
     # make the dump
-    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST $DUMPVARS | gzip > ${TMPDIR}/${TARGET}
+    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST $DUMPVARS | gzip > ${TMPDIR}/${SOURCE}
 
     # Execute additional scripts for post processing. For example, create a new
     # backup file containing this db backup and a second tar file with the
@@ -189,7 +193,7 @@ else
     if [ -d /scripts.d/post-backup/ ]; then
       for i in $(ls /scripts.d/post-backup/*.sh); do
         if [ -x $i ]; then
-          NOW=${now} DUMPFILE=${TMPDIR}/${TARGET} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} $i
+          NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} $i
         fi
       done
     fi
@@ -197,7 +201,7 @@ else
     # Execute a script to modify the name of the target file before uploading to the dump target.
     # For example, uploading to a date stamped object key path in S3, i.e. s3://bucket/2018/08/23/path
     if [ -f /scripts.d/target.sh ] && [ -x /scripts.d/target.sh ]; then
-        TARGET=$(NOW=${now} DUMPFILE=${TMPDIR}/${TARGET} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/target.sh)
+        TARGET=$(NOW=${now} DUMPFILE=${TMPDIR}/${SOURCE} DUMPDIR=${uri[path]} DB_DUMP_DEBUG=${DB_DUMP_DEBUG} /scripts.d/target.sh)
 
         if [ -z "${TARGET}" ]; then
             echo "Your target script located at /scripts.d/target.sh must return a value to stdout"
@@ -209,13 +213,13 @@ else
     case "${uri[schema]}" in
       "file")
         mkdir -p ${uri[path]}
-        mv ${TMPDIR}/${TARGET} ${uri[path]}/${TARGET}
+        mv ${TMPDIR}/${SOURCE} ${uri[path]}/${TARGET}
         ;;
       "s3")
         # allow for endpoint url override
         [[ -n "$AWS_ENDPOINT_URL" ]] && AWS_ENDPOINT_OPT="--endpoint-url $AWS_ENDPOINT_URL"
-        aws ${AWS_ENDPOINT_OPT} s3 cp ${TMPDIR}/${TARGET} "${DB_DUMP_TARGET}/${TARGET}"
-        /bin/rm ${TMPDIR}/${TARGET}
+        aws ${AWS_ENDPOINT_OPT} s3 cp ${TMPDIR}/${SOURCE} "${DB_DUMP_TARGET}/${TARGET}"
+        /bin/rm ${TMPDIR}/${SOURCE}
         ;;
       "smb")
         if [[ -n "$SMB_USER" ]]; then
@@ -234,8 +238,8 @@ else
           UDOM=
         fi
 
-        smbclient -N "//${uri[host]}/${uri[share]}" ${UPASSARG} "${UPASS}" ${UDOM} -c "cd ${uri[sharepath]}; put ${TMPDIR}/${TARGET} ${TARGET}"
-        /bin/rm ${TMPDIR}/${TARGET}
+        smbclient -N "//${uri[host]}/${uri[share]}" ${UPASSARG} "${UPASS}" ${UDOM} -c "cd ${uri[sharepath]}; put ${TMPDIR}/${SOURCE} ${TARGET}"
+        /bin/rm ${TMPDIR}/${SOURCE}
        ;;
     esac
 

--- a/test/_functions.sh
+++ b/test/_functions.sh
@@ -11,6 +11,7 @@ function configure_backup_directory_target() {
 	# replace SEQ if needed
 	t2=${t/SEQ/${seqno}}
 	mkdir -p ${BACKUP_DIRECTORY_BASE}/${seqno}/data
+	chmod -R 0777 ${BACKUP_DIRECTORY_BASE}/${seqno}
 	echo "target: ${t2}" >> ${BACKUP_DIRECTORY_BASE}/${seqno}/list
 
 	# are we working with nopath?

--- a/test/_functions.sh
+++ b/test/_functions.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Configure backup directory
+function configure_backup_directory_target() {
+    local t=$1
+	local seqno=$2
+	# where will we store
+	# create the backups directory
+	# clear the target
+	# replace SEQ if needed
+	t2=${t/SEQ/${seqno}}
+	mkdir -p ${BACKUP_DIRECTORY_BASE}/${seqno}/data
+	echo "target: ${t2}" >> ${BACKUP_DIRECTORY_BASE}/${seqno}/list
+
+	# are we working with nopath?
+	if [[ "$t2" =~ nopath ]]; then
+		rm -f ${BACKUP_DIRECTORY_BASE}/nopath
+		ln -s ${seqno}/data ${BACKUP_DIRECTORY_BASE}/nopath
+	fi
+
+	echo ${t2}
+}
+
+function get_default_source() {
+    echo "db_backup_*.gz"
+}
+
+function get_default_target() {
+    $(get_default_source)
+}

--- a/test/_functions.sh
+++ b/test/_functions.sh
@@ -25,7 +25,3 @@ function configure_backup_directory_target() {
 function get_default_source() {
     echo "db_backup_*.gz"
 }
-
-function get_default_target() {
-    $(get_default_source)
-}

--- a/test/test.sh
+++ b/test/test.sh
@@ -291,7 +291,7 @@ for ((i=0; i< ${#targets[@]}; i++)); do
 	((seq++)) || true
 done
 
-[[ "$DEBUG" != "0" ]] && echo "Stopping and removing smb and mysql containers"
+[[ "$DEBUG" != "0" ]] && echo "Stopping and removing smb, mysql and s3 containers"
 CMD1="docker kill $smb_cid $mysql_cid $s3_cid"
 CMD2="docker rm $smb_cid $mysql_cid $s3_cid"
 if [[ "$DEBUG" == "0" ]]; then

--- a/test/test_source_target.sh
+++ b/test/test_source_target.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+set -e
+
+source ./_functions.sh
+
+DEBUG=${DEBUG:-0}
+[[ -n "$DEBUG" && "$DEBUG" == "verbose" ]] && DEBUG=1
+[[ -n "$DEBUG" && "$DEBUG" == "debug" ]] && DEBUG=2
+
+[[ "$DEBUG" == "2" ]] && set -x
+
+BACKUP_IMAGE=mysqlbackup_backup_test:latest
+SMB_IMAGE=mysqlbackup_smb_test:latest
+BACKUP_DIRECTORY_BASE=/tmp/backups
+
+RWD=${PWD}
+MYSQLUSER=user
+MYSQLPW=abcdefg
+MYSQLDUMP=/tmp/source/backup.gz
+
+mkdir -p /tmp/source
+
+# list of sources and targets
+declare -a targets
+
+# localhost is not going to work, because it is across containers!!
+# fill in with a var
+targets=(
+"file:///backups/SEQ/data"
+"smb://user:pass@smb/auth/SEQ/data"
+"s3://mybucket/SEQ/data"
+)
+
+function run_default_source_target_test() {
+    local t=$1
+	local seqno=$2
+
+	local t2=$(configure_backup_directory_target ${t} ${seqno})
+
+    # if in DEBUG, make sure backup also runs in DEBUG
+	if [[ "$DEBUG" != "0" ]]; then
+		DBDEBUG="-e DB_DUMP_DEBUG=2"
+	else
+		DBDEBUG=
+	fi
+
+    # change our target
+    cid=$(docker run --net mysqltest -d $DBDEBUG -e DB_USER=$MYSQLUSER -e DB_PASS=$MYSQLPW -e DB_DUMP_FREQ=60 -e DB_DUMP_BEGIN=+0 -e DB_DUMP_TARGET=${t2} -e AWS_ACCESS_KEY_ID=abcdefg -e AWS_SECRET_ACCESS_KEY=1234567 -e AWS_ENDPOINT_URL=http://s3:443/ -v /tmp/backups/${seqno}/:/scripts.d/ -v /tmp/backups:/backups -e DB_SERVER=mysql --link ${s3_cid}:mybucket.s3.amazonaws.com ${BACKUP_IMAGE})
+	echo $cid
+}
+
+# check test
+function checktest() {
+	local t=$1
+	local seqno=$2
+	local cid=$3
+	local SOURCE_FILE=$4
+	local TARGET_FILE=$5
+
+	# where do we expect backups?
+	bdir=/tmp/backups/${seqno}/data		# change our target
+	if [[ "$DEBUG" != "0" ]]; then
+		ls -la $bdir
+	fi
+
+	# stop and remove the container
+	[[ "$DEBUG" != "0" ]] && echo "Stopping and removing ${cid}"
+	CMD1="docker kill ${cid}"
+	CMD2="docker rm ${cid}"
+	if [[ "$DEBUG" == "0" ]]; then
+		$CMD1 > /dev/null 2>&1
+		$CMD2 > /dev/null 2>&1
+	else
+		# keep the logs
+		docker logs ${cid}
+		$CMD1
+		$CMD2
+	fi
+
+	# check that the expected backups are in the right place
+	BACKUP_FILE=$(ls -d1 $bdir/${SOURCE_FILE} 2>/dev/null)
+
+    [[ "$DEBUG" != "0" ]] && echo "Checking target backup file exists for target ${t}"
+
+	# check for the directory
+	if [[ ! -d "$bdir" ]]; then
+		fail+=("$seqno: $t missing $bdir")
+	elif [[ -z "$BACKUP_FILE" ]]; then
+		fail+=("$seqno: $t missing zip file")
+	else
+	    pass+=($seqno)
+	fi
+
+	[[ "$DEBUG" != "0" ]] && echo "Checking target backup filename matches expected ${t}"
+
+	[[ ${BACKUP_FILE##*/} == ${TARGET_FILE} ]] && pass+=($seqno) || fail+=("$seqno: $t uploaded target file name does not match expected")
+}
+
+# we need to run through each each target and test the backup.
+# before the first run, we:
+# - start the sql database
+# - populate it with a few inserts/creates
+# - run a single clear backup
+# for each stage, we:
+# - clear the target
+# - run the backup
+# - check that the backup now is there in the right format
+# - clear the target
+
+declare -a cids
+# make the parent for the backups
+
+[[ "$DEBUG" != "0" ]] && echo "Resetting backups directory"
+
+/bin/rm -rf /tmp/backups
+mkdir -p /tmp/backups
+chmod -R 0777 /tmp/backups
+
+# build the core images
+QUIET="-q"
+[[ "$DEBUG" != "0" ]] && QUIET=""
+[[ "$DEBUG" != "0" ]] && echo "Creating backup image"
+docker build $QUIET -t ${BACKUP_IMAGE} -f ../Dockerfile ../
+
+# build the test images we need
+[[ "$DEBUG" != "0" ]] && echo "Creating smb image"
+docker build $QUIET -t ${SMB_IMAGE} -f ./Dockerfile_smb .
+
+# create the network we need
+[[ "$DEBUG" != "0" ]] && echo "Creating the test network"
+docker network create mysqltest
+
+# run the test images we need
+[[ "$DEBUG" != "0" ]] && echo "Running smb, s3 and mysql containers"
+[[ "$DEBUG" != "0" ]] && SMB_IMAGE="$SMB_IMAGE -F -d 25"
+smb_cid=$(docker run --net mysqltest --name=smb  -d -p 445:445 -v /tmp/backups:/share/backups -t ${SMB_IMAGE})
+mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:5.7)
+s3_cid=$(docker run --net mysqltest --name s3 -d -v /tmp/backups:/fakes3_root/s3/mybucket lphoward/fake-s3 -r /fakes3_root -p 443)
+
+
+# Allow up to 20 seconds for the database to be ready
+db_connect="docker exec -i $mysql_cid mysql -u$MYSQLUSER -p$MYSQLPW --wait --connect_timeout=20 tester"
+retry_count=0
+retryMax=20
+retrySleep=1
+until [[ $retry_count -ge $retryMax ]]; do
+	set +e
+	$db_connect -e 'select 1;'
+	success=$?
+	set -e
+	[[ $success == 0 ]] && break
+	((retry_count  ++)) || true
+	sleep $retrySleep
+done
+# did we succeed?
+if [[ $success != 0 ]]; then
+	echo -n "failed to connect to database after $retryMax tries." >&2
+fi
+
+echo 'use tester; create table t1 (id INT, name VARCHAR(20)); INSERT INTO t1 (id,name) VALUES (1, "John"), (2, "Jill"), (3, "Sam"), (4, "Sarah");' | $db_connect
+docker exec $mysql_cid mysqldump -hlocalhost --protocol=tcp -A -u$MYSQLUSER -p$MYSQLPW | gzip > ${MYSQLDUMP}
+
+# keep track of the sequence
+seq=0
+
+#
+
+
+#
+# do the file tests
+[[ "$DEBUG" != "0" ]] && echo "Doing tests"
+# create each target
+[[ "$DEBUG" != "0" ]] && echo "Running backups for each target"
+for ((i=0; i< ${#targets[@]}; i++)); do
+	t=${targets[$i]}
+	cids[$seq]=$(run_default_source_target_test $t $seq)
+	# increment our counter
+	((seq++)) || true
+done
+total=$seq
+
+# now wait for everything
+waittime=10
+[[ "$DEBUG" != "0" ]] && echo "Waiting ${waittime} seconds to complete backup runs"
+sleep ${waittime}s
+
+
+# get logs from the tests
+if [[ "$DEBUG" == "2" ]]; then
+	echo
+	echo "SMB LOGS:"
+	docker logs $smb_cid
+	echo
+	echo "MYSQL LOGS:"
+	docker logs $mysql_cid
+	echo
+	echo "S3 LOGS:"
+	docker logs $s3_cid
+fi
+
+# now check each result
+[[ "$DEBUG" != "0" ]] && echo "Checking results"
+declare -a fail
+declare -a pass
+seq=0
+for ((i=0; i< ${#targets[@]}; i++)); do
+	t=${targets[$i]}
+	checktest $t $seq ${cids[$seq]} $(get_default_source) $(get_default_target)
+	# increment our counter
+	((seq++)) || true
+done
+
+[[ "$DEBUG" != "0" ]] && echo "Stopping and removing smb and mysql containers"
+CMD1="docker kill $smb_cid $mysql_cid $s3_cid"
+CMD2="docker rm $smb_cid $mysql_cid $s3_cid"
+if [[ "$DEBUG" == "0" ]]; then
+	$CMD1 > /dev/null 2>&1
+	$CMD2 > /dev/null 2>&1
+else
+	$CMD1
+	$CMD2
+fi
+
+[[ "$DEBUG" != "0" ]] && echo "Removing docker network"
+docker network rm mysqltest
+
+# report results
+echo "Passed: ${#pass[@]}"
+echo "Failed: ${#fail[@]}"
+
+if [[ "${#fail[@]}" != "0" ]]; then
+	for ((i=0; i< ${#fail[@]}; i++)); do
+		echo "${fail[$i]}"
+	done
+	exit 1
+else
+	exit 0
+fi


### PR DESCRIPTION
Implemented a plugin for overriding the dump file name **before** it gets uploaded to the dump target.

PR for issue: https://github.com/deitch/mysql-backup/issues/52

@deitch I gave some thought to testing this upgrade, but your test script would not complete each time I tried. I kept getting the following error repeated in my shell:

     ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)

Looking at your script, all mysql commands are run within containers, so there should be no requirement for me to have the mysql server installed on my host. Is there a specific way I need to run your test script?