### PR TITLE
No longer run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # mysql backup image
-FROM alpine:3.7
+FROM alpine:3.8
 MAINTAINER Avi Deitcher <https://github.com/deitch>
 
 # install the necessary client
-RUN apk add --update mysql-client bash python3 samba-client && \
+RUN apk add --update mysql-client bash python3 samba-client shadow && \
     rm -rf /var/cache/apk/* && \
     touch /etc/samba/smb.conf && \
     pip3 install awscli
+
+# set us up to run as non-root user
+RUN groupadd -g 1005 appuser && \
+    useradd -r -u 1005 -g appuser appuser
+USER appuser
 
 # install the entrypoint
 COPY functions.sh /


### PR DESCRIPTION
No good reason for it to run as root... and it does make the tests more brittle. This is better.