### PR TITLE
Option to override keeping permissions for file: targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `SMB_PASS`: SMB password. May also be specified in `DB_DUMP_TARGET` with an `smb://` url. If both specified, this variable overrides the value in the URL.
 * `COMPRESSION`: Compression to use. Supported are: `gzip` (default), `bzip2`
 * `DB_DUMP_BY_SCHEMA`: Whether to use separate files per schema in the compressed file (`true`), or a single dump file (`false`). Defaults to `false`.
+* `DB_DUMP_KEEP_PERMISSIONS`: Whether to keep permissions for a file target. By default, `mysql-backup` copies the backup compressed file to the target with `cp -a`. In certain filesystems with certain permissions, this may cause errors. You can disable the `-a` flag by setting `DB_DUMP_KEEP_PERMISSIONS=false`. Defaults to `true`.
 
 In addition, any environment variable that starts with `MYSQLDUMP_` will have the `MYSQLDUMP_` part stripped off, and the rest passed as an option to `mysqldump`. For example, `MYSQLDUMP_max_allowed_packet=123455678` will run `mysqldump --max_allowed_packet=123455678`.
 

--- a/entrypoint
+++ b/entrypoint
@@ -19,6 +19,7 @@ file_env "DB_DUMP_BEGIN" "+0"
 file_env "DB_DUMP_DEBUG"
 file_env "DB_DUMP_TARGET" "/backup"
 file_env "DB_DUMP_BY_SCHEMA"
+file_env "DB_DUMP_KEEP_PERMISSIONS" "true"
 
 file_env "DB_RESTORE_TARGET"
 

--- a/functions.sh
+++ b/functions.sh
@@ -178,7 +178,9 @@ function backup_target() {
   case "${uri[schema]}" in
     "file")
       mkdir -p ${uri[path]}
-      cp -a ${TMPDIR}/${SOURCE} ${uri[path]}/${TARGET}
+      cpOpts="-a"
+      [ -n "$DB_DUMP_KEEP_PERMISSIONS" -a "$DB_DUMP_KEEP_PERMISSIONS" = "false" ] && cpOpts=""
+      cp $cpOpts ${TMPDIR}/${SOURCE} ${uri[path]}/${TARGET}
       ;;
     "s3")
       # allow for endpoint url override


### PR DESCRIPTION
In certain circumstances - e.g. some NFS shares on Windows - if the `DB_DUMP_TARGET` is a `file:///` target, it may have issues copying the file with permissions (`cp -a`). This provides an option to disable it.

Fixes #65 