### PR TITLE
Consolidate all mysqldump opts to a single option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ __You should consider the [use of `--env-file=`](https://docs.docker.com/engine/
 * `COMPRESSION`: Compression to use. Supported are: `gzip` (default), `bzip2`
 * `DB_DUMP_BY_SCHEMA`: Whether to use separate files per schema in the compressed file (`true`), or a single dump file (`false`). Defaults to `false`.
 * `DB_DUMP_KEEP_PERMISSIONS`: Whether to keep permissions for a file target. By default, `mysql-backup` copies the backup compressed file to the target with `cp -a`. In certain filesystems with certain permissions, this may cause errors. You can disable the `-a` flag by setting `DB_DUMP_KEEP_PERMISSIONS=false`. Defaults to `true`.
+* `MYSQLDUMP_OPTS`: A string of options to pass to `mysqldump`, e.g. `MYSQLDUMP_OPTS="--opt abc --param def --max_allowed_packet=123455678"` will run `mysqldump --opt abc --param def --max_allowed_packet=123455678`
 
-In addition, any environment variable that starts with `MYSQLDUMP_` will have the `MYSQLDUMP_` part stripped off, and the rest passed as an option to `mysqldump`. For example, `MYSQLDUMP_max_allowed_packet=123455678` will run `mysqldump --max_allowed_packet=123455678`.
 
 ### Permissions
 By default, the backup/restore process does **not** run as root (UID O). Whenever possible, you should run processes (not just in containers) as users other than root. In this case, it runs as username `appuser` with UID/GID `1005`.

--- a/entrypoint
+++ b/entrypoint
@@ -38,6 +38,9 @@ if [[ -n "$DB_DUMP_DEBUG" ]]; then
   set -x
 fi
 
+# ensure it is defined
+MYSQLDUMP_OPTS=${MYSQLDUMP_OPTS:-}
+
 # login credentials
 if [ -n "${DB_USER}" ]; then
   DBUSER="-u${DB_USER}"
@@ -49,13 +52,6 @@ if [ -n "${DB_PASS}" ]; then
 else
   DBPASS=
 fi
-
-# capture our var settings
-DUMPVARS=""
-for i in $(env | awk -F_ '/^MYSQLDUMP_/ {print $2}'); do
-  DUMPVARS="${DUMPVARS} --${i}"
-done
-
 
 # database server
 if [ -z "${DB_SERVER}" ]; then

--- a/functions.sh
+++ b/functions.sh
@@ -118,7 +118,7 @@ function do_dump() {
       DB_NAMES=$(mysql -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS -N -e 'show databases')
     fi
     for onedb in $DB_NAMES; do
-      mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS --databases ${onedb} $DUMPVARS > $workdir/${onedb}_${now}.sql
+      mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS --databases ${onedb} $MYSQLDUMP_OPTS > $workdir/${onedb}_${now}.sql
     done
   else
     # just a single command
@@ -127,7 +127,7 @@ function do_dump() {
     else
       DB_LIST="-A"
     fi
-    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST $DUMPVARS > $workdir/backup_${now}.sql
+    mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS $DB_LIST $MYSQLDUMP_OPTS > $workdir/backup_${now}.sql
   fi
   tar -C $workdir -cvf - . | $COMPRESS > ${TMPDIR}/${SOURCE}
   rm -rf $workdir


### PR DESCRIPTION
Makes it easier to pass in multiple and possibly complex options to `mysqldump`.