### PR TITLE
Alpine 3.9, mariadb 3.0.8 support for caching_sha2 auth, test against mysql 8.0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # mysql backup image
-FROM alpine:3.8
+FROM alpine:3.9
 MAINTAINER Avi Deitcher <https://github.com/deitch>
 
 # install the necessary client
-RUN apk add --update mysql-client bash python3 samba-client shadow && \
+RUN apk add --update mysql-client mariadb-connector-c bash python3 samba-client shadow && \
     rm -rf /var/cache/apk/* && \
     touch /etc/samba/smb.conf && \
     pip3 install awscli

--- a/test/Dockerfile_smb
+++ b/test/Dockerfile_smb
@@ -1,5 +1,4 @@
-# rancher server backup image
-FROM alpine:3.7
+FROM alpine:3.9
 MAINTAINER https://github.com/deitch
 
 # smb port
@@ -17,4 +16,4 @@ RUN adduser user -D -H
 RUN echo user:pass | chpasswd
 
 # run samba in the foreground
-CMD /usr/sbin/smbd -F -S -d 4 < /dev/null
+CMD /usr/sbin/smbd -F -S -d 4 --no-process-group

--- a/test/test_dump.sh
+++ b/test/test_dump.sh
@@ -239,7 +239,7 @@ docker network create mysqltest
 # run the test images we need
 [[ "$DEBUG" != "0" ]] && echo "Running smb, s3 and mysql containers"
 smb_cid=$(docker run --net mysqltest --name=smb  -d -p 445:445 -v ${TMPBACKUPDIR}:/share/backups -t ${SMB_IMAGE})
-mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:5.7)
+mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:8.0)
 s3_cid=$(docker run --net mysqltest --name s3 -d -v ${TMPBACKUPDIR}:/fakes3_root/s3/mybucket lphoward/fake-s3 -r /fakes3_root -p 443)
 
 

--- a/test/test_source_target.sh
+++ b/test/test_source_target.sh
@@ -135,7 +135,7 @@ docker network create mysqltest
 # run the test images we need
 [[ "$DEBUG" != "0" ]] && echo "Running smb, s3 and mysql containers"
 smb_cid=$(docker run --net mysqltest --name=smb  -d -p 445:445 -v ${BACKUP_DIRECTORY_BASE}:/share/backups:z -t ${SMB_IMAGE})
-mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source:z -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:5.7)
+mysql_cid=$(docker run --net mysqltest --name mysql -d -v /tmp/source:/tmp/source:z -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tester -e MYSQL_USER=$MYSQLUSER -e MYSQL_PASSWORD=$MYSQLPW mysql:8.0)
 s3_cid=$(docker run --net mysqltest --name s3 -d -v ${BACKUP_DIRECTORY_BASE}:/fakes3_root/s3/mybucket:z lphoward/fake-s3 -r /fakes3_root -p 443)
 
 # Allow up to 20 seconds for the database to be ready


### PR DESCRIPTION
This **cannot** yet be merged. However, once alpine 3.9 goes GA, it should be ready to go.